### PR TITLE
feat: Multi thread parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC			= icx
-CFLAGS		= -std=c11 -Wall -O3
-LDFLAGS 	= -lmkl_rt -qopenmp
+CFLAGS		= -std=c11 -Wall -O3 -qopenmp
+LDFLAGS 	= -lmkl_rt
 SRCS		= $(wildcard *.c)
 OBJS		= $(SRCS:.c=.o)
 

--- a/coo.c
+++ b/coo.c
@@ -3,30 +3,34 @@
 #include <string.h>
 #include <math.h>
 #include <stdbool.h>
+#include <ctype.h>
 #include "coo.h"
 #include "util.h"
 
 void parse_to_coo(char *src_line, Coo *dist) {
 	int row, column;
 	double value;
-	char *tok, *endptr;
+	char *cur, *endptr;
+	cur = src_line;
 
-	tok = strtok(src_line, " ");
-	row = (int)strtol(tok, &endptr, 10);
-	if (endptr == tok || *endptr != '\0') {
-		fprintf(stderr, "Error: Invalid integer %s\n", tok);
+	while (isspace(*cur)) cur++;
+	row = (int)strtol(cur, &endptr, 10);
+	if (endptr == cur) {
+		fprintf(stderr, "Error: Invalid integer %s\n", cur);
 		exit(EXIT_FAILURE);
 	}
+	cur = endptr;
 	
-	tok = strtok(NULL, " ");
-	column = (int)strtol(tok, &endptr, 10);
-	if (endptr == tok || *endptr != '\0') {
-		fprintf(stderr, "Error: Invalid integer %s\n", tok);
+	while (isspace(*cur)) cur++;
+	column = (int)strtol(cur, &endptr, 10);
+	if (endptr == cur) {
+		fprintf(stderr, "Error: Invalid integer %s\n", cur);
 		exit(EXIT_FAILURE);
 	}
+	cur = endptr;
 
-	tok = strtok(NULL, " ");
-	sscanf(tok, "%lg", &value);
+	while (isspace(*cur)) cur++;
+	sscanf(cur, "%lg", &value);
 
 	// fortran は 1-index, c は 0-index
 	dist->index_row = row - 1;
@@ -67,6 +71,7 @@ Mat_Coo read_mat_coo(char *filepath) {
 	entries = malloc(sizeof(Coo) * line_count);
 	);
 
+	#pragma omp parallel for
 	for (int i = 0; i < line_count; i++) {
 		parse_to_coo(lines[i], &entries[i]);
 	}

--- a/coo.h
+++ b/coo.h
@@ -2,7 +2,7 @@
 typedef struct coo {
 	int 		index_row;
 	int 		index_column;
-	double 	value;
+	double 		value;
 } Coo;
 
 typedef struct mat_coo {
@@ -10,8 +10,6 @@ typedef struct mat_coo {
 	int 	length;
 	int 	dimension;
 } Mat_Coo;
-
-
 
 extern void parse_to_coo(char *src_str, Coo *dist);
 extern Mat_Coo read_mat_coo(char *filepath);

--- a/main.c
+++ b/main.c
@@ -12,9 +12,7 @@ int main(int argc, char *argv[]) {
 	char *filename;
 	Mat_Coo mat;
 	double eigenvalues[buf_size];
-	double *eigenvectors[buf_size];
-
-	double start_time, end_time;
+	double *eigenvectors[buf_size];\
 
 	if (argc != 2) {
 		fprintf(stderr, "Usage: %s <input_file>\n", argv[0]);
@@ -22,10 +20,10 @@ int main(int argc, char *argv[]) {
 	}
 	filename = argv[1];
 
-	start_time = omp_get_wtime();
-	mat = read_mat_coo(filename);
-	end_time = omp_get_wtime();
-	printf("[TIME] read_mat_coo elapsed time: %.6f sec\n", end_time - start_time);
+	MEASURE(read_mat,
+		mat = read_mat_coo(filename);
+	);
+
 
 	printf("mat dim: %d\n", mat.dimension);
 	
@@ -33,10 +31,9 @@ int main(int argc, char *argv[]) {
 		eigenvectors[i] = calloc(mat.dimension, sizeof(double));
 	}
 	
-	start_time = omp_get_wtime();
-	lanczos(&mat, eigenvalues, eigenvectors, number_of_eigenvalues, 100, 10e-5);
-	end_time = omp_get_wtime();
-	printf("[TIME] lanczos elapsed time: %.6f sec\n", end_time - start_time);
+	MEASURE(lanczos,
+		lanczos(&mat, eigenvalues, eigenvectors, number_of_eigenvalues, 100, 10e-5);
+	);
 
 	for (int i = 0; i < number_of_eigenvalues; i++) {
 		printf("eigenvalue\t\t%d\t%.12f\n", i + 1, eigenvalues[i]);

--- a/util.c
+++ b/util.c
@@ -5,6 +5,43 @@
 #include <mkl_lapacke.h>
 #include "util.h"
 
+char *read_from_file(char *filepath) {
+  FILE *fp;
+  char *head;
+  size_t read_bytes, total_bytes = 0;
+
+  fp = fopen(filepath, "r");
+  if (fp == NULL) {
+    perror("fopen");
+    exit(EXIT_FAILURE);
+  }
+
+  head = NULL;
+
+  read_bytes = -1;
+  while (read_bytes != 0) {
+    head = realloc(head, total_bytes + BUFSIZ + 1);
+    if (head == NULL) {
+      fprintf(stderr, "realloc failed\n");
+      free(head);
+      fclose(fp);
+      exit(EXIT_FAILURE);
+    }
+
+    read_bytes = fread(head + total_bytes, sizeof(char), BUFSIZ, fp);
+    if (ferror(fp)) {
+      perror("fread");
+      free(head);
+      fclose(fp);
+      exit(EXIT_FAILURE);
+    }
+    total_bytes += read_bytes;
+  }
+  head[total_bytes] = '\0';
+
+  return head;
+}
+
 void gaussian_random_vec(int n, double *r) {
   int iseed[4];
   srand((unsigned int)time(NULL));

--- a/util.h
+++ b/util.h
@@ -1,6 +1,16 @@
+#include <omp.h>
 
-#define max(x, y) (x >= y ? x : y)
+#define MAX(a, b) ((a) >= (b) ? (a) : (b))
+#define MIN(a, b) ((a) <  (b) ? (a) : (b))
+#define MEASURE(label, code) \
+    do { \
+        double __st = omp_get_wtime(); \
+        code \
+        double __en = omp_get_wtime(); \
+        printf("[TIME] %s: %lf sec\n", #label, __en - __st); \
+    } while(0)
 
+extern char *read_from_file(char *filepath);
 extern void gaussian_random_vec(int n, double *r);
 extern double dot_product(double *a, double *b, int size);
 extern void diagonalize_double(double **symmetric_matrix, double *eigenvalues, double **eigenvectors, int n);


### PR DESCRIPTION
ファイル読み込み部分をマルチスレッド化することにより、読み込み時間を短縮

cal6 での実行結果
|before|after|
|--|--|
|`[TIME] read_mat_coo elapsed time: 7.400512 sec`|`[TIME] read_mat: 2.316029 sec`|

